### PR TITLE
Add compatibility for CodeCommit's new default branch being 'main'

### DIFF
--- a/lib/cfnguardian/codecommit.rb
+++ b/lib/cfnguardian/codecommit.rb
@@ -10,16 +10,24 @@ module CfnGuardian
       @repo_name = repo_name
       @client = Aws::CodeCommit::Client.new()
     end
-    
-    def get_last_commit(branch='main')
+
+    def get_last_commit(branch='master')
       resp = @client.get_branch({
         repository_name: @repo_name,
         branch_name: branch,
       })
       return resp.branch.commit_id
     end
+
+    def create_main_branch(branch='main')
+      last_master_commit = get_last_commit('master')
+      resp = @client.create_branch({
+        repository_name: @repo_name,
+        branch_name: branch, 
+        commit_id: commit
+      })
     
-    def get_commit_history(branch='main',count=10)
+    def get_commit_history(branch='master',count=10)
       history = []
       commit = get_last_commit(branch)
       

--- a/lib/cfnguardian/codecommit.rb
+++ b/lib/cfnguardian/codecommit.rb
@@ -11,7 +11,7 @@ module CfnGuardian
       @client = Aws::CodeCommit::Client.new()
     end
     
-    def get_last_commit(branch='master')
+    def get_last_commit(branch='main')
       resp = @client.get_branch({
         repository_name: @repo_name,
         branch_name: branch,
@@ -19,7 +19,7 @@ module CfnGuardian
       return resp.branch.commit_id
     end
     
-    def get_commit_history(branch='master',count=10)
+    def get_commit_history(branch='main',count=10)
       history = []
       commit = get_last_commit(branch)
       

--- a/lib/cfnguardian/codecommit.rb
+++ b/lib/cfnguardian/codecommit.rb
@@ -27,7 +27,7 @@ module CfnGuardian
         commit_id: last_master_commit
       })
     
-    def get_commit_history(branch='master',count=10)
+    def get_commit_history(branch='main',count=10)
       history = []
       commit = get_last_commit(branch)
       

--- a/lib/cfnguardian/codecommit.rb
+++ b/lib/cfnguardian/codecommit.rb
@@ -24,7 +24,7 @@ module CfnGuardian
       resp = @client.create_branch({
         repository_name: @repo_name,
         branch_name: branch, 
-        commit_id: commit
+        commit_id: last_master_commit
       })
     
     def get_commit_history(branch='master',count=10)


### PR DESCRIPTION
_"Starting on March 4, 2021 at 17:00 UTC, repositories created with an initial commit of code using AWS CloudFormation stacks will use 'main' instead of 'master' as the name of the default branch. To avoid impact from this change, you should update your templates to use the BranchName property or modify any code that expects 'master' as the default branch. For more information, see the documentation and this support article."_

CodeCommit now creates a _main_ repo instead of _master_ which Guardian has not yet been updated to reflect. This change intends to create a new branch called _main_ that is initialised from the last commit to _master_ which should ensure backwards compatibility for updates to existing pipelines