### PR TITLE
Added VPN_Tunnel component

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.7-alpine
 
-ARG GUARDIAN_VERSION="0.6.6"
+ARG GUARDIAN_VERSION="0.6.7"
 
 COPY . /src
 

--- a/lib/cfnguardian/compile.rb
+++ b/lib/cfnguardian/compile.rb
@@ -40,6 +40,7 @@ require 'cfnguardian/resources/amazonmq_rabbitmq'
 require 'cfnguardian/resources/batch'
 require 'cfnguardian/resources/glue'
 require 'cfnguardian/resources/step_functions'
+require 'cfnguardian/resources/vpn_tunnel'
 require 'cfnguardian/version'
 require 'cfnguardian/error'
 

--- a/lib/cfnguardian/config/defaults.yaml
+++ b/lib/cfnguardian/config/defaults.yaml
@@ -100,4 +100,6 @@ Resources:
         Query: Default
   SQSQueue:
   - Id: Default
+  VPNTunnel:
+  - Id: Default
   

--- a/lib/cfnguardian/models/alarm.rb
+++ b/lib/cfnguardian/models/alarm.rb
@@ -445,6 +445,17 @@ module CfnGuardian
         @dimensions = { StorageAccount: resource['Id'], StorageContainer: resource['Container'] }
       end
     end
+
+    class VPNTunnelAlarm < BaseAlarm
+      def initialize(resource)
+        super(resource)
+        @group = 'VPNTunnel'
+        @namespace = 'AWS/VPN'
+        @dimensions = {
+          TunnelIpAddress: resource['Id']
+        }
+      end
+    end
     
   end
 end

--- a/lib/cfnguardian/models/event_subscription.rb
+++ b/lib/cfnguardian/models/event_subscription.rb
@@ -107,5 +107,6 @@ module CfnGuardian
     class NetworkTargetGroupEventSubscription < BaseEventSubscription; end
     class RedshiftClusterEventSubscription < BaseEventSubscription; end
     class StepFunctionsSubscription < BaseEventSubscription; end
+    class VPNTunnelEventSubscription < BaseEventSubscription; end
   end
 end

--- a/lib/cfnguardian/resources/vpn_tunnel.rb
+++ b/lib/cfnguardian/resources/vpn_tunnel.rb
@@ -1,0 +1,18 @@
+module CfnGuardian::Resource
+    class VPNTunnel < Base
+      
+      def default_alarms    
+        alarm = CfnGuardian::Models::VPNTunnelAlarm.new(@resource)
+        alarm.name = 'VPNTunnelState'
+        alarm.metric_name = 'TunnelState'
+        alarm.comparison_operator = 'LessThanThreshold'
+        alarm.statistic = 'Minimum'
+        alarm.threshold = 1
+        alarm.evaluation_periods = 5
+        alarm.treat_missing_data = 'breaching'
+        alarm.datapoints_to_alarm = 5
+        @alarms.push(alarm)
+      end
+      
+    end
+end


### PR DESCRIPTION
Adding VPN Tunnel monitoring

It seems to build fine:
```
❯ gem build cfn-guardian.gemspec
WARNING:  description and summary are identical
WARNING:  See https://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: cfn-guardian
  Version: 0.6.7
  File: cfn-guardian-0.6.7.gem
❯ gem install cfn-guardian-0.6.7.gem
Successfully installed cfn-guardian-0.6.7
Parsing documentation for cfn-guardian-0.6.7
Done installing documentation for cfn-guardian after 0 seconds
1 gem installed
❯ cfn-guardian compile --config alarms.yaml --region us-east-1
could not extract property type for Parameters from AWSDataBrewRecipeAction, assuming Json
{"Documentation"=>"http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-databrew-recipe-action.html#cfn-databrew-recipe-action-parameters", "UpdateType"=>"Mutable", "Required"=>false}
INFO: Cloudformation templates compiled successfully in out/ directory
INFO: Creating bucket xxxxxxxxxxx.us-east-1.guardian.templates
INFO: Validating template out/guardian.compiled.yaml locally
INFO: Validating template out/guardian-stack-0.compiled.yaml locally
INFO: Cloudformation templates were validated successfully
WARN: AWS cloudwatch alarms defined in the templates will cost roughly $0.60 per month
```