### PR TITLE
Set Queue name as Id for Queue resource to make sure alarms are unique

### DIFF
--- a/lib/cfnguardian/config/defaults.yaml
+++ b/lib/cfnguardian/config/defaults.yaml
@@ -8,7 +8,7 @@ Resources:
     Node: Default
   AmazonMQRabbitMQQueue:
   - Id: Default
-    Queue: Default
+    Broker: Default
     Vhost: Default
   ApiGateway:
   - Id: Default

--- a/lib/cfnguardian/models/alarm.rb
+++ b/lib/cfnguardian/models/alarm.rb
@@ -122,8 +122,8 @@ module CfnGuardian
         @group = 'AmazonMQRabbitMQQueue'
         @namespace = 'AWS/AmazonMQ'
         @dimensions = { 
-          Broker: resource['Id'],
-          Queue: resource['Queue'],
+          Broker: resource['Broker'],
+          Queue: resource['Id'],
           VirtualHost: resource['Vhost']
         }
       end


### PR DESCRIPTION
Currently since Id is set as the Broker name, adding multiple Queue resources results in only the last one having alarm resources in the final template since the unique resource hash is based on the Id. In this fix I've switched the Id to be the queue name, which seems more appropriate for the resource group and resolves the issue