### PR TITLE
Set missing data to notBreaching for APIGW and lambda

### DIFF
--- a/lib/cfnguardian/resources/apigateway.rb
+++ b/lib/cfnguardian/resources/apigateway.rb
@@ -26,6 +26,7 @@ module CfnGuardian::Resource
       alarm.statistic = 'Average'
       alarm.threshold = 1000
       alarm.evaluation_periods = 2
+      alarm.treat_missing_data = 'notBreaching'
       @alarms.push(alarm)
     end
     

--- a/lib/cfnguardian/resources/lambda.rb
+++ b/lib/cfnguardian/resources/lambda.rb
@@ -6,18 +6,21 @@ module CfnGuardian::Resource
       alarm.name = 'LambdaErrors'
       alarm.metric_name = 'Errors'
       alarm.threshold = 0.5
+      alarm.treat_missing_data = 'notBreaching'
       @alarms.push(alarm)
       
       alarm = CfnGuardian::Models::LambdaAlarm.new(@resource)
       alarm.name = 'Throttles'
       alarm.metric_name = 'Throttles'
       alarm.threshold = 0.5
+      alarm.treat_missing_data = 'notBreaching'
       @alarms.push(alarm)
       
       alarm = CfnGuardian::Models::LambdaAlarm.new(@resource)
       alarm.name = 'DeadLetterErrors'
       alarm.metric_name = 'DeadLetterErrors'
       alarm.threshold = 0.5
+      alarm.treat_missing_data = 'notBreaching'
       @alarms.push(alarm)
       
       alarm = CfnGuardian::Models::LambdaAlarm.new(@resource)


### PR DESCRIPTION
All of these alarms' default behaviour is to not receive data, so they should be in OK state not INSUFFICIENT_DATA state when not in ALARM state.