### PR TITLE
Fixing duplicated CpuCreditBalanceCritical for lib/cfnguardian/resources/amazonmq_broker.rb

### DIFF
--- a/lib/cfnguardian/resources/amazonmq_broker.rb
+++ b/lib/cfnguardian/resources/amazonmq_broker.rb
@@ -13,7 +13,7 @@ module CfnGuardian::Resource
       @alarms.push(alarm)
       
       alarm = CfnGuardian::Models::AmazonMQBrokerAlarm.new(@resource)
-      alarm.name = 'CpuCreditBalanceCritical'
+      alarm.name = 'CpuCreditBalanceWarning'
       alarm.metric_name = 'CpuCreditBalance'
       alarm.comparison_operator = 'LessThanThreshold'
       alarm.statistic = 'Minimum'


### PR DESCRIPTION
Fix [#42](https://github.com/base2Services/cfn-guardian/issues/42).

The [wrong name is set](https://github.com/base2Services/cfn-guardian/blob/5633c67a6f7742da780abad0661ace6840b03344/lib/cfnguardian/resources/amazonmq_broker.rb#L16) for the CpuCreditBalanceWarning default alarm.

```yaml
alarm = CfnGuardian::Models::AmazonMQBrokerAlarm.new(@resource)
alarm.name = 'CpuCreditBalanceCritical' # CpuCreditBalanceWarning
alarm.metric_name = 'CpuCreditBalance'
alarm.comparison_operator = 'LessThanThreshold'
alarm.statistic = 'Minimum'
alarm.threshold = 30
alarm.evaluation_periods = 1
alarm.treat_missing_data = 'notBreaching'
alarm.alarm_action = 'Warning'
@alarms.push(alarm)
```