### PR TITLE
Set metric filter alarms to treat missing data as not breaching

### DIFF
--- a/lib/cfnguardian/resources/log_group.rb
+++ b/lib/cfnguardian/resources/log_group.rb
@@ -11,6 +11,7 @@ module CfnGuardian::Resource
         alarm = CfnGuardian::Models::LogGroupAlarm.new(@resource)
         alarm.name = filter['MetricName']
         alarm.metric_name = filter['MetricName']
+        alarm.treat_missing_data = 'notBreaching'
         @alarms.push(alarm)
       end
     end


### PR DESCRIPTION
Majority of the time a metric filter will not be receiving data, so it will sit in INSUFFICIENT_DATA until it receives data and goes into ALARM, then back afterwards, there is no possibility for it to go into OK state.

I'm on a quest to make INSUFFICIENT_DATA a thing of the past!