### PR TITLE
Set CloudFront alarms to treat missing data as notBreaching

### DIFF
--- a/lib/cfnguardian/models/alarm.rb
+++ b/lib/cfnguardian/models/alarm.rb
@@ -141,6 +141,7 @@ module CfnGuardian
         }
         @statistic = 'Average'
         @evaluation_periods = 5
+        @treat_missing_data = 'notBreaching'
       end
     end
     


### PR DESCRIPTION
All of the alarms for CloudFront distributions are for error rates, which the majority of the time shouldn't have any data.