### PR TITLE
Fix error and add section for EventSubscriptions

### DIFF
--- a/docs/event_subscriptions.md
+++ b/docs/event_subscriptions.md
@@ -10,7 +10,7 @@ As with the default alarms in Guardian, there are default events for some resour
 
 ## Overriding Defaults
 
-Default properites of the events can be overridden through the config YAML using the `EventsSubscriptions` top level key.
+Default properties of the events can be overridden through the config YAML using the `EventsSubscriptions` top level key.
 For example here we are changing the topic the event is being send to.
 
 ```yaml

--- a/docs/event_subscriptions.md
+++ b/docs/event_subscriptions.md
@@ -10,14 +10,14 @@ As with the default alarms in Guardian, there are default events for some resour
 
 ## Overriding Defaults
 
-Default properites of the events can be overridden through the config YAML using the `EventsSubscription` top level key.
+Default properites of the events can be overridden through the config YAML using the `EventsSubscriptions` top level key.
 For example here we are changing the topic the event is being send to.
 
 ```yaml
 Topics:
     CustomEvents: arn:aws:sns....
 
-EventSubscription:
+EventSubscriptions:
   Ec2Instance:
     InstanceTerminated:
       Topic: CustomEvents
@@ -28,7 +28,7 @@ EventSubscription:
 Default events can be disabled, the same way default alarms can be disabled through the config YAML.
 
 ```yaml
-EventSubscription:
+EventSubscriptions:
   Ec2Instance:
     # set the instance terminated event to false to disable the event
     InstanceTerminated: false
@@ -44,7 +44,7 @@ This is useful if you want to create a new event and a default event already has
 The following example inherits the `MasterPasswordReset` RDS event and creates a new event that captures the security group add to an rds instance event.
 
 ```yaml
-EventSubscription:
+EventSubscriptions:
   RDSInstance:
     # Create a new event name
     DBNewSecurityGroup:
@@ -59,7 +59,7 @@ EventSubscription:
 If there are no default events that match the format you require you can create an event of the base event subscription model.
 
 ```yaml
-EventSubscription:
+EventSubscriptions:
   ECSCluster:
     ContainerInstanceStateChange:
       Source: aws.ecs

--- a/docs/event_subscriptions.md
+++ b/docs/event_subscriptions.md
@@ -34,6 +34,18 @@ EventSubscriptions:
     InstanceTerminated: false
 ```
 
+## Enabling Default Events
+
+Some templates may have events that are disabled by default, they can be enabled using a slightly different syntax to disabling.
+
+```yaml
+EventSubscriptions:
+  RDSInstance:
+    # set the replication failure event to true to enable the event
+    ReplicationFailure: 
+      Enabled: true
+```
+
 ## Creating Custom Events
 
 Custom events can be created if there are not defaults for that event. They can be inherited from a default event or from the base event model.


### PR DESCRIPTION
Through a lot of trial and error and looking at the code, I found out that the config block for event subscriptions is wrong in the docs. It needs to be `EventSubscriptions` (plural).

Confirmation can be found here: https://github.com/base2Services/cfn-guardian/blob/4c12dc62e7f7f6f1012992bd0022522f66be87c6/lib/cfnguardian/compile.rb#L67

It's also not very clear what the syntax for enabling subscriptions is, so I added a section to instruct what the syntax is. I decided this was necessary since the syntax for disabling is different, which is a bit confusing.