### PR TITLE
Fix default properties for ec2 status check alarm

### DIFF
--- a/lib/cfnguardian/resources/ec2_instance.rb
+++ b/lib/cfnguardian/resources/ec2_instance.rb
@@ -14,8 +14,9 @@ module CfnGuardian
         alarm = CfnGuardian::Models::Ec2InstanceAlarm.new(@resource)
         alarm.name = 'StatusCheckFailed'
         alarm.metric_name = 'StatusCheckFailed'
-        alarm.threshold = 90
-        alarm.evaluation_periods = 10
+        alarm.threshold = 0
+        alarm.evaluation_periods = 1
+        alarm.comparison_operator = 'GreaterThanThreshold'
         @alarms.push(alarm)
 
         alarm = CfnGuardian::Models::Ec2InstanceAlarm.new(@resource)


### PR DESCRIPTION
I assume this alarm was a victim of a copy/paste of the CPU Utilisation alert above it. According to official docs:

```
StatusCheckFailed
Reports whether the instance has passed both the instance status check and the system status check in the last minute.
This metric can be either 0 (passed) or 1 (failed).                 
By default, this metric is available at a 1-minute frequency at no charge.
```