### PR TITLE
Set the thresholds for NRPE alarms

### DIFF
--- a/lib/cfnguardian/resources/nrpe.rb
+++ b/lib/cfnguardian/resources/nrpe.rb
@@ -16,11 +16,13 @@ module CfnGuardian::Resource
           alarm = CfnGuardian::Models::NrpeAlarm.new(host,@environment)
           alarm.name = "#{command.to_camelcase}Warning"
           alarm.metric_name = command
+          alarm.threshold = 0
           @alarms.push(alarm)
           
           alarm = CfnGuardian::Models::NrpeAlarm.new(host,@environment)
           alarm.name = "#{command.to_camelcase}Critical"
           alarm.metric_name = command
+          alarm.threshold = 1
           @alarms.push(alarm)
         end
       end


### PR DESCRIPTION
Currently both warning and critical alarms are set to alarm if they receive data greater than 0, this change defines them to make it clearer and so that critical alarms are correct.