### PR TITLE
Disable lambda duration by default

### DIFF
--- a/lib/cfnguardian/resources/lambda.rb
+++ b/lib/cfnguardian/resources/lambda.rb
@@ -27,6 +27,7 @@ module CfnGuardian::Resource
       @alarms.push(alarm)
       
       alarm = CfnGuardian::Models::LambdaAlarm.new(@resource)
+      alarm.enabled = false
       alarm.name = 'Duration'
       alarm.metric_name = 'Duration'
       alarm.statistic = 'Average'


### PR DESCRIPTION
This alarm is largely unnecessary as the duration only really matters if the function times out, which would set off the errors alarm anyway.

This is to disable it by default so that it is only used if someone has a specific need for it.