### PR TITLE
Add optional event subscription for db cluster failover finished events

### DIFF
--- a/lib/cfnguardian/resources/rds_cluster.rb
+++ b/lib/cfnguardian/resources/rds_cluster.rb
@@ -8,6 +8,15 @@ module CfnGuardian::Resource
         event_subscription.message = 'A failover for the DB cluster has failed.'
         @event_subscriptions.push(event_subscription)
       end
+
+      def default_event_subscriptions()
+        event_subscription = CfnGuardian::Models::RDSClusterEventSubscription.new(@resource)
+        event_subscription.name = 'FailoverFinished'
+        event_subscription.rds_event_category = 'failover'
+        event_subscription.message = 'A failover for the DB cluster has finished.'
+        event_subscription.enabled = false
+        @event_subscriptions.push(event_subscription)
+      end
   
     end
   end


### PR DESCRIPTION
For scenarios where successful failovers require attention.
EG: When a cluster has a smaller reader than its writer, and a manual failover back to the larger instance is required.

https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_Events.Messages.html#USER_Events.Messages.cluster