### PR TITLE
Specify alarm action in NRPE

### DIFF
--- a/lib/cfnguardian/resources/nrpe.rb
+++ b/lib/cfnguardian/resources/nrpe.rb
@@ -17,12 +17,14 @@ module CfnGuardian::Resource
           alarm.name = "#{command.to_camelcase}Warning"
           alarm.metric_name = command
           alarm.threshold = 0
+          alarm.alarm_action = 'Warning'
           @alarms.push(alarm)
           
           alarm = CfnGuardian::Models::NrpeAlarm.new(host,@environment)
           alarm.name = "#{command.to_camelcase}Critical"
           alarm.metric_name = command
           alarm.threshold = 1
+          alarm.alarm_action = 'Critical'
           @alarms.push(alarm)
         end
       end


### PR DESCRIPTION
Currently, both the warning and critical alarms for NRPE are assigned the critical alarm action. This change is mostly to make it so warnings are actually warnings, but also to make it clear for criticals as well. 