### PR TITLE
Set latency to disabled by default

### DIFF
--- a/lib/cfnguardian/resources/apigateway.rb
+++ b/lib/cfnguardian/resources/apigateway.rb
@@ -24,6 +24,7 @@ module CfnGuardian::Resource
       alarm.statistic = 'Average'
       alarm.threshold = 1000
       alarm.evaluation_periods = 2
+      alarm.enabled = false
       @alarms.push(alarm)
     end
     


### PR DESCRIPTION
Like with lambda function duration and target group target response time, this metric is not useful in most cases.