### PR TITLE
Updated web socket check

### DIFF
--- a/lib/cfnguardian/models/check.rb
+++ b/lib/cfnguardian/models/check.rb
@@ -53,7 +53,7 @@ module CfnGuardian
         @name = 'WebSocketCheck'
         @package = 'websocket-check'
         @handler = 'handler.websocket_check'
-        @version = '1f242f6741f6b561f22f6761a1287e7a0b69d06f'
+        @version = 'fb374fcf606b921d3745d7171d81ab5a32135d2f'
         @runtime = 'python3.7'
         @branch = 'main'
       end

--- a/lib/cfnguardian/models/event.rb
+++ b/lib/cfnguardian/models/event.rb
@@ -89,7 +89,7 @@ module CfnGuardian
         @endpoint = resource['Id']
         @message = resource.fetch('Message',nil)
         @expected_response = resource.fetch('Expected_Response',nil)
-        @timeout = resource.fetch('Timeout',50)
+        @timeout = resource.fetch('Timeout',30)
         @payload = resource.fetch('Payload',nil)
       end
       
@@ -98,6 +98,7 @@ module CfnGuardian
           'ENDPOINT' => @endpoint,
           'MESSAGE' => @message,
           'EXPECTED_RESPONSE' => @expected_response
+          'TIMEOUT' => @timeout
         }
         payload['PAYLOAD'] = @payload unless @payload.nil?
         return payload.to_json

--- a/lib/cfnguardian/models/event.rb
+++ b/lib/cfnguardian/models/event.rb
@@ -97,7 +97,7 @@ module CfnGuardian
         payload = {
           'ENDPOINT' => @endpoint,
           'MESSAGE' => @message,
-          'EXPECTED_RESPONSE' => @expected_response
+          'EXPECTED_RESPONSE' => @expected_response,
           'TIMEOUT' => @timeout
         }
         payload['PAYLOAD'] = @payload unless @payload.nil?


### PR DESCRIPTION
- Updated defaults in web socket check lambda
```
      self.defaults = {
            self.ENDPOINT : 'www.google.com',
            self.MESSAGE : '{}',
            self.EXPECTED_RESPONSE : '{',
            self.CW_METRICS_NAMESPACE: 'WebSocketCheck',
            self.REPORT_AS_CW_METRICS: '1',
            self.TIMEOUT : 30
        }
```
- Changed timeout to configurable value via alarms.yaml file
```
Resources:
  WebSocket:
  - Id: 'www.google.com'
    Message: '{}'
    Expected_Response: '{'
    Timeout: 45
```
- Fixed error output in TimeTaken
```
return {'Available': 0, 'TimeTaken': int((t2 - t0) * 1000)}
```

Changes to aws-lambda-websocket [here](https://github.com/base2Services/aws-lambda-websocket-check/commit/01e4837e8e33099dcce310b0db779f0ed447eef8) and [here](https://github.com/base2Services/aws-lambda-websocket-check/commit/fb374fcf606b921d3745d7171d81ab5a32135d2f) 