### PR TITLE
Reduce datapoints for three lambda alarms

### DIFF
--- a/lib/cfnguardian/resources/elastic_search.rb
+++ b/lib/cfnguardian/resources/elastic_search.rb
@@ -20,6 +20,7 @@ module CfnGuardian::Resource
         alarm.evaluation_periods = 5
         alarm.datapoints_to_alarm = 3
         alarm.alarm_action = 'Warning'
+        alarm.enabled = false
         @alarms.push(alarm)
 
         alarm = CfnGuardian::Models::ElasticSearchAlarm.new(@resource)
@@ -28,6 +29,7 @@ module CfnGuardian::Resource
         alarm.threshold = 92
         alarm.evaluation_periods = 5
         alarm.alarm_action = 'Critical'
+        alarm.enabled = false
         @alarms.push(alarm)
 
         alarm = CfnGuardian::Models::ElasticSearchAlarm.new(@resource)

--- a/lib/cfnguardian/resources/lambda.rb
+++ b/lib/cfnguardian/resources/lambda.rb
@@ -6,18 +6,24 @@ module CfnGuardian::Resource
       alarm.name = 'LambdaErrors'
       alarm.metric_name = 'Errors'
       alarm.threshold = 0.5
+      alarms.evaluation_periods = 1
+      alarms.datapoints_to_alarm = 1
       @alarms.push(alarm)
       
       alarm = CfnGuardian::Models::LambdaAlarm.new(@resource)
       alarm.name = 'Throttles'
       alarm.metric_name = 'Throttles'
       alarm.threshold = 0.5
+      alarms.evaluation_periods = 1
+      alarms.datapoints_to_alarm = 1
       @alarms.push(alarm)
       
       alarm = CfnGuardian::Models::LambdaAlarm.new(@resource)
       alarm.name = 'DeadLetterErrors'
       alarm.metric_name = 'DeadLetterErrors'
       alarm.threshold = 0.5
+      alarms.evaluation_periods = 1
+      alarms.datapoints_to_alarm = 1
       @alarms.push(alarm)
       
       alarm = CfnGuardian::Models::LambdaAlarm.new(@resource)


### PR DESCRIPTION
The default in the base lambda alarm is 5 datapoints 5 evaluation periods, which doesn't really make sense for these alarms as far as I'm aware. It makes more sense to have them just be one datapoint.