### PR TITLE
Feature/alarm tagging fix

### DIFF
--- a/lib/cfnguardian/tagger.rb
+++ b/lib/cfnguardian/tagger.rb
@@ -27,13 +27,15 @@ module CfnGuardian
 
       if tags_changed?(current_tags, new_tags)
         logger.debug "Updating tags on alarm #{alarm_arn}"
+        new_tags.delete_if {|key, value| value.include?('?')}
         begin
           @client.tag_resource({
             resource_arn: alarm_arn,
             tags: new_tags.map {|key,value| {key: key, value: value}}
           })
         rescue Aws::CloudWatch::Errors::InvalidParameterValue => e
-          logger.debug "Caught invalid character in #{e}"
+          logger.debug "Failed due to invalid character in tags for: #{alarm_arn}"
+        end
       end
     end
 

--- a/lib/cfnguardian/tagger.rb
+++ b/lib/cfnguardian/tagger.rb
@@ -27,10 +27,13 @@ module CfnGuardian
 
       if tags_changed?(current_tags, new_tags)
         logger.debug "Updating tags on alarm #{alarm_arn}"
-        @client.tag_resource({
-          resource_arn: alarm_arn,
-          tags: new_tags.map {|key,value| {key: key, value: value}}
-        })
+        begin
+          @client.tag_resource({
+            resource_arn: alarm_arn,
+            tags: new_tags.map {|key,value| {key: key, value: value}}
+          })
+        rescue Aws::CloudWatch::Errors::InvalidParameterValue => e
+          logger.debug "Caught invalid character in #{e}"
       end
     end
 


### PR DESCRIPTION
Add fix to simply remove keys with unsupported `?` character.

**Example:**
Using a SQS Queue resource as an example.

1) Observe resource has no existing tags yet.
   <img width="121" alt="Screen Shot 2023-03-07 at 2 51 57 pm" src="https://user-images.githubusercontent.com/64295670/223316344-98327625-63d8-4b8d-96e3-e852d8cf8961.png">

2) We tag the resource with the following configuration
```
Resources:
  SQSQueue:
  - Id: testqueuetags

Templates:
  SQSQueue:
    GroupOverrides:
      Tags:
       badtag: bad???value
       goodtag: goodvalue
       anotherbadtag: bad?value
       anothergoodvalue: anothergoodvalue
```
We then call `cfn-guardian tag-alarms --config=alarmsconfig.yaml --debug`

3) Observe the added alarms 
```
{
    "Tags": [
        {
            "Key": "anothergoodvalue",
            "Value": "anothergoodvalue"
        },
        {
            "Key": "guardian:resource:id",
            "Value": "testqueuetags"
        },
        {
            "Key": "guardian:alarm:severity",
            "Value": "Critical"
        },
        {
            "Key": "goodtag",
            "Value": "goodvalue"
        },
        {
            "Key": "guardian:resource:group",
            "Value": "SQSQueue"
        },
        {
            "Key": "guardian:config:yaml",
            "Value": "alarmsconfig.yaml"
        },
        {
            "Key": "guardian:stack:name",
            "Value": "guardianalarmsconfig.yaml-"
        },
        {
            "Key": "guardian:alarm:name",
            "Value": "ApproximateAgeOfOldestMessage"
        },
        {
            "Key": "guardian:alarm:metric",
            "Value": "ApproximateAgeOfOldestMessage"
        }
    ]
}
```
Tags with invalid values have been skipped whilst valid tags are still added as expected.



