### PR TITLE
check if name is set in the mg so it doesnt match against a nil value in the alarm

### DIFF
--- a/lib/cfnguardian/compile.rb
+++ b/lib/cfnguardian/compile.rb
@@ -131,7 +131,7 @@ module CfnGuardian
               res = @resources.find {|r| 
                 (r.type == 'Alarm') && 
                 (r.group == group && r.name == alarm) &&
-                (r.resource_id == resource['Id'] || r.resource_name == resource['Name'])}
+                (r.resource_id == resource['Id'] || (!resource['Name'].nil? && r.resource_name == resource['Name']))}
 
               unless res.nil?
                 res.maintenance_groups.append("#{maintenance_group}MaintenanceGroup")


### PR DESCRIPTION
Example config 

```yaml
Resources:
  DynamoDBTable:
  - Id: table-1
  - Id: table-2
  - Id: table-3
  - Id: table-4
MaintenanceGroups:
  DynamoReadUsage:    # doesn't work
    Schedules:
      Disable: '55 23 * * ? *'
      Enable: '20 0 * * ? *'
      Debug: true
    DynamoDBTable:
      DynamoDBReadUsage:
      - Id: table-4
 ```

The issue was that because both the `Name` in the MaintenanceGroup and the resource friendly name were not set it matched on the first entry in the resource group because both values were nil.

the change added was to check if the `Name` in the MaintenanceGroup is not nil so we dont match nil values and match on the resource id.