### PR TITLE
dont create alarms when there is no match for loggroups when overriding values via the template block

### DIFF
--- a/lib/cfnguardian/resources/base.rb
+++ b/lib/cfnguardian/resources/base.rb
@@ -84,8 +84,11 @@ module CfnGuardian::Resource
         
         alarms = find_alarms(name)
 
-        if alarms.empty?
+        if alarms.empty? && !['LogGroup'].any?(group)
           # if the alarm doesn't exist and it's not being inherited from another alarm create a new alarm
+          # and is a supported a resource group.
+          # unsupported resource groups
+          # - LogGroup: this is not required as alarms are defined in the Metric Filters object in the resource group
           resources = @resource.has_key?('Hosts') ? @resource['Hosts'] : [@resource]
           resources.each do |res|
             alarm = Kernel.const_get("CfnGuardian::Models::#{self.class.to_s.split('::').last}Alarm").new(res)


### PR DESCRIPTION
with the following config

```yaml
Resources:
  LogGroup:
  - Id: log-group
    MetricFilters:
    - MetricName: 'TimeoutError'
      Pattern: 'Connection Timed Out'
    - MetricName: 'ErorrLog'
      Pattern: 'error'
  - Id: log-group-2
    MetricFilters:
    - MetricName: 'TimeoutError2'
      Pattern: 'Connection Timed Out'
    - MetricName: 'ErorrLog2'
      Pattern: 'error'

Templates:
  LogGroup:
    TimeoutError:
      Threshold: 10
    ErorrLog:
      Threshold: 10
    TimeoutError2:
      Threshold: 20
    ErorrLog2:
      Threshold: 20
```

we are able to successfully override alarm property values defined on the log groups

The default behavior for the template block is if there isn't a default alarm that matches a new alarm is created with the details defined in the template. But as this is not want the loggroup resource group is excluded from this behavior. 