### PR TITLE
update sftp check to include timeout property

### DIFF
--- a/docs/custom_checks/sftp.md
+++ b/docs/custom_checks/sftp.md
@@ -39,6 +39,8 @@ Resources:
     File: file.txt
     # optionally check for a regex match pattern in the body of the file
     FileBodyMatch: ok
+    # optionally override the default connection timeout of 10 seconds
+    Timeout: 10
 ```
 
 ## Private SFTP Check
@@ -70,4 +72,5 @@ Resources:
       PrivateKeyPass: /ssm/path/privatekey/password
       File: file.txt
       FileBodyMatch: ok
+      Timeout: 10
 ```

--- a/lib/cfnguardian/models/check.rb
+++ b/lib/cfnguardian/models/check.rb
@@ -189,7 +189,7 @@ module CfnGuardian
         @name = 'SFTPCheck'
         @package = 'sftp-check'
         @handler = 'handler.sftp_check'
-        @version = '987e71f2607347e13e3f156535059d6d3ce1ceed'
+        @version = '901a63a0b9bbb4f09d1efae7049b20de4a1a22e2'
         @runtime = 'python3.7'
       end
     end

--- a/lib/cfnguardian/models/event.rb
+++ b/lib/cfnguardian/models/event.rb
@@ -287,6 +287,7 @@ module CfnGuardian
         @private_key_pass = resource.fetch('PrivateKeyPass', nil)
         @file = resource.fetch('File', nil)
         @file_regex_match = resource.fetch('FileRegexMatch', nil)
+        @timeout = resource.fetch('Timeout', nil)
       end
       
       def payload
@@ -301,6 +302,7 @@ module CfnGuardian
         payload['PRIVATEKEY_PASSWORD'] = @private_key_pass unless @private_key_pass.nil?
         payload['FILE'] = @file unless @file.nil?
         payload['FILE_REGEX_MATCH'] = @file_regex_match unless @file_regex_match.nil?
+        payload['TIMEOUT'] = @timeout unless @timeout.nil?
         return payload.to_json
       end
       


### PR DESCRIPTION
- Add ability to override the default connection timeout for SFTP and InternalSFTP checks

```yaml
Resources:
  SFTP:
  - Id: sftp.example.com
    User: user
    ServerKey: public-server-key
    PrivateKey: /ssm/path/privatekey
    # optionally override the default connection timeout of 10 seconds
    Timeout: 10
```

- ServerKey is now a required property, before it was optional. this is for security improvements.