### PR TITLE
change rds event structure to use EventID instead of message to match events

### DIFF
--- a/lib/cfnguardian.rb
+++ b/lib/cfnguardian.rb
@@ -215,6 +215,7 @@ module CfnGuardian
     method_option :config, aliases: :c, type: :array, desc: "yaml config files", required: true
     method_option :region, aliases: :r, type: :string, desc: "set the AWS region"
     method_option :tags, type: :hash, desc: "additional tags on the cloudformation stack"
+    method_option :check_resources_exist, type: :boolean, default: true, desc: "check each resource exists in the aws account"
 
     def tag_alarms
       set_log_level(options[:debug])
@@ -233,7 +234,7 @@ module CfnGuardian
         tags[:'guardian:config:yaml'] = config
 
         logger.info "tagging alarms from config file #{config}"
-        compiler = CfnGuardian::Compile.new(config)
+        compiler = CfnGuardian::Compile.new(config, options[:check_resources_exist])
         compiler.get_resources
         alarms = compiler.alarms
         global_tags = compiler.global_tags.merge(tags)

--- a/lib/cfnguardian/models/event_subscription.rb
+++ b/lib/cfnguardian/models/event_subscription.rb
@@ -48,16 +48,31 @@ module CfnGuardian
           raise "#{self.class} missing `EventID` property"
         end
 
-        return {
-          EventID: [@event_id],
-          SourceIdentifier: ["rds:#{@resource_id}"]
-        }
+        return { EventID: [@event_id] }
       end
     end
 
-    class RDSInstanceEventSubscription < RDSEventSubscription; end
-    class RDSClusterEventSubscription < RDSEventSubscription; end
-    class RDSClusterInstanceEventSubscription < RDSEventSubscription; end
+    class RDSInstanceEventSubscription < RDSEventSubscription
+      def initialize(resource)
+        super(resource)
+        @resource_arn = "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:#{@resource_id}"
+      end
+    end
+
+    class RDSClusterEventSubscription < RDSEventSubscription
+      def initialize(resource)
+        super(resource)
+        @resource_arn = "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:#{@resource_id}"
+      end
+    end
+
+
+    class RDSClusterInstanceEventSubscription < RDSEventSubscription
+      def initialize(resource)
+        super(resource)
+        @resource_arn = "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:#{@resource_id}"
+      end
+    end
 
     class Ec2InstanceEventSubscription < BaseEventSubscription
       def initialize(resource)

--- a/lib/cfnguardian/models/event_subscription.rb
+++ b/lib/cfnguardian/models/event_subscription.rb
@@ -35,7 +35,7 @@ module CfnGuardian
     end
 
     class RDSEventSubscription < BaseEventSubscription
-      attr_accessor :source_id, :rds_event_category, :message
+      attr_accessor :event_id
 
       def initialize(resource)
         super(resource)

--- a/lib/cfnguardian/models/event_subscription.rb
+++ b/lib/cfnguardian/models/event_subscription.rb
@@ -40,36 +40,24 @@ module CfnGuardian
       def initialize(resource)
         super(resource)
         @source = 'aws.rds'
-        @detail_type = 'RDS DB Instance Event'
-        @source_id = ''
-        @rds_event_category = ''
-        @message = ''
+        @event_id = nil
       end
 
       def detail
+        if @event_id.nil?
+          raise "#{self.class} missing `EventID` property"
+        end
+
         return {
-          EventCategories: [@rds_event_category],
-          SourceType: [@source_type],
-          SourceIdentifier: ["rds:#{@resource_id}"],
-          Message: [@message]
+          EventID: [@event_id],
+          SourceIdentifier: ["rds:#{@resource_id}"]
         }
       end
     end
 
-    class RDSInstanceEventSubscription < RDSEventSubscription
-      def initialize(resource)
-        super(resource)
-        @source_type = 'DB_INSTANCE'
-      end
-    end
-
-    class RDSClusterEventSubscription < RDSEventSubscription
-      def initialize(resource)
-        super(resource)
-        @detail_type = 'RDS DB Cluster Event'
-        @source_type = 'DB_CLUSTER'
-      end
-    end
+    class RDSInstanceEventSubscription < RDSEventSubscription; end
+    class RDSClusterEventSubscription < RDSEventSubscription; end
+    class RDSClusterInstanceEventSubscription < RDSEventSubscription; end
 
     class Ec2InstanceEventSubscription < BaseEventSubscription
       def initialize(resource)

--- a/lib/cfnguardian/resources/rds_cluster.rb
+++ b/lib/cfnguardian/resources/rds_cluster.rb
@@ -4,15 +4,22 @@ module CfnGuardian::Resource
       def default_event_subscriptions()
         event_subscription = CfnGuardian::Models::RDSClusterEventSubscription.new(@resource)
         event_subscription.name = 'FailoverFailed'
-        event_subscription.rds_event_category = 'failover'
-        event_subscription.message = 'A failover for the DB cluster has failed.'
+        event_subscription.event_id = 'RDS-EVENT-0069'
         @event_subscriptions.push(event_subscription)
 
         event_subscription = CfnGuardian::Models::RDSClusterEventSubscription.new(@resource)
         event_subscription.name = 'FailoverFinished'
-        event_subscription.rds_event_category = 'failover'
-        event_subscription.message = 'A failover for the DB cluster has finished.'
-        event_subscription.enabled = false
+        event_subscription.event_id = 'RDS-EVENT-0071'
+        @event_subscriptions.push(event_subscription)
+
+        event_subscription = CfnGuardian::Models::RDSClusterEventSubscription.new(@resource)
+        event_subscription.name = 'FailoverStartedSameAZ'
+        event_subscription.event_id = 'RDS-EVENT-0072'
+        @event_subscriptions.push(event_subscription)
+
+        event_subscription = CfnGuardian::Models::RDSClusterEventSubscription.new(@resource)
+        event_subscription.name = 'FailoverStartedDifferentAZ'
+        event_subscription.event_id = 'RDS-EVENT-0073'
         @event_subscriptions.push(event_subscription)
       end
   

--- a/lib/cfnguardian/resources/rds_cluster_instance.rb
+++ b/lib/cfnguardian/resources/rds_cluster_instance.rb
@@ -25,6 +25,23 @@ module CfnGuardian::Resource
       alarm.evaluation_periods = 10
       @alarms.push(alarm)
     end
+
+    def default_event_subscriptions()
+      event_subscription = CfnGuardian::Models::RDSInstanceEventSubscription.new(@resource)
+      event_subscription.name = 'MasterPasswordReset'
+      event_subscription.event_id = 'RDS-EVENT-0016'
+      @event_subscriptions.push(event_subscription)
+
+      event_subscription = CfnGuardian::Models::RDSInstanceEventSubscription.new(@resource)
+      event_subscription.name = 'MasterPasswordResetFailure'
+      event_subscription.event_id = 'RDS-EVENT-0067'
+      @event_subscriptions.push(event_subscription)
+      
+      event_subscription = CfnGuardian::Models::RDSClusterInstanceEventSubscription.new(@resource)
+      event_subscription.name = 'AuroraStorageLow'
+      event_subscription.event_id = 'RDS-EVENT-0227'
+      @event_subscriptions.push(event_subscription)
+    end
     
   end
 end

--- a/lib/cfnguardian/resources/rds_instance.rb
+++ b/lib/cfnguardian/resources/rds_instance.rb
@@ -57,71 +57,100 @@ module CfnGuardian::Resource
     def default_event_subscriptions()
       event_subscription = CfnGuardian::Models::RDSInstanceEventSubscription.new(@resource)
       event_subscription.name = 'MasterPasswordReset'
-      event_subscription.rds_event_category = 'configuration change'
-      event_subscription.message = 'The master password for the DB instance has been reset.'
+      event_subscription.event_id = 'RDS-EVENT-0016'
       @event_subscriptions.push(event_subscription)
 
       event_subscription = CfnGuardian::Models::RDSInstanceEventSubscription.new(@resource)
       event_subscription.name = 'MasterPasswordResetFailure'
-      event_subscription.rds_event_category = 'configuration change'
-      event_subscription.message = 'An attempt to reset the master password for the DB instance has failed.'
+      event_subscription.event_id = 'RDS-EVENT-0067'
       @event_subscriptions.push(event_subscription)
 
       event_subscription = CfnGuardian::Models::RDSInstanceEventSubscription.new(@resource)
       event_subscription.name = 'Deletion'
-      event_subscription.rds_event_category = 'deletion'
-      event_subscription.message = 'The DB instance has been deleted.'
+      event_subscription.event_id = 'RDS-EVENT-0003'
+      @event_subscriptions.push(event_subscription)
+
+      event_subscription = CfnGuardian::Models::RDSInstanceEventSubscription.new(@resource)
+      event_subscription.name = 'StorageFullShutDown'
+      event_subscription.event_id = 'RDS-EVENT-0221'
+      @event_subscriptions.push(event_subscription)
+
+      event_subscription = CfnGuardian::Models::RDSInstanceEventSubscription.new(@resource)
+      event_subscription.name = 'StorageCapacityLow'
+      event_subscription.event_id = 'RDS-EVENT-0222'
+      @event_subscriptions.push(event_subscription)
+      
+      event_subscription = CfnGuardian::Models::RDSInstanceEventSubscription.new(@resource)
+      event_subscription.name = 'InvalidState'
+      event_subscription.event_id = 'RDS-EVENT-0219'
+      @event_subscriptions.push(event_subscription)
+
+      event_subscription = CfnGuardian::Models::RDSInstanceEventSubscription.new(@resource)
+      event_subscription.name = 'StorageScalingReachedThreshold'
+      event_subscription.event_id = 'RDS-EVENT-0224'
+      @event_subscriptions.push(event_subscription)
+
+      event_subscription = CfnGuardian::Models::RDSInstanceEventSubscription.new(@resource)
+      event_subscription.name = 'StorageScalingFailed'
+      event_subscription.event_id = 'RDS-EVENT-0223'
+      @event_subscriptions.push(event_subscription)
+
+      event_subscription = CfnGuardian::Models::RDSInstanceEventSubscription.new(@resource)
+      event_subscription.name = 'MultiAZStandByFailoverStarted'
+      event_subscription.event_id = 'RDS-EVENT-0013'
+      @event_subscriptions.push(event_subscription)
+
+      event_subscription = CfnGuardian::Models::RDSInstanceEventSubscription.new(@resource)
+      event_subscription.name = 'MultiAZStandByFailoverCompleted'
+      event_subscription.event_id = 'RDS-EVENT-0015'
       @event_subscriptions.push(event_subscription)
 
       event_subscription = CfnGuardian::Models::RDSInstanceEventSubscription.new(@resource)
       event_subscription.name = 'MultiAZFailoverStarted'
-      event_subscription.rds_event_category = 'failover'
-      event_subscription.message = 'A Multi-AZ failover that resulted in the promotion of a standby instance has started.'
+      event_subscription.event_id = 'RDS-EVENT-0049'
       @event_subscriptions.push(event_subscription)
 
       event_subscription = CfnGuardian::Models::RDSInstanceEventSubscription.new(@resource)
-      event_subscription.name = 'MultiAZFailoverComplete'
-      event_subscription.rds_event_category = 'failover'
-      event_subscription.message = 'A Multi-AZ failover has completed.'
+      event_subscription.name = 'MultiAZFailoverCompleted'
+      event_subscription.event_id = 'RDS-EVENT-0050'
+      @event_subscriptions.push(event_subscription)
+
+      event_subscription = CfnGuardian::Models::RDSInstanceEventSubscription.new(@resource)
+      event_subscription.name = 'NotAttemptingFailover'
+      event_subscription.event_id = 'RDS-EVENT-0034'
       @event_subscriptions.push(event_subscription)
 
       event_subscription = CfnGuardian::Models::RDSInstanceEventSubscription.new(@resource)
       event_subscription.name = 'DBFailure'
-      event_subscription.rds_event_category = 'failure'
-      event_subscription.message = 'The DB instance has failed due to an incompatible configuration or an underlying storage issue. Begin a point-in-time-restore for the DB instance.'
+      event_subscription.event_id = 'RDS-EVENT-0031'
       @event_subscriptions.push(event_subscription)
 
       event_subscription = CfnGuardian::Models::RDSInstanceEventSubscription.new(@resource)
       event_subscription.name = 'TableCountExceedsRecommended'
-      event_subscription.rds_event_category = 'notification'
-      event_subscription.message = 'The number of tables you have for your DB instance exceeds the recommended best practices for Amazon RDS.'
+      event_subscription.event_id = 'RDS-EVENT-0055'
       @event_subscriptions.push(event_subscription)
 
       event_subscription = CfnGuardian::Models::RDSInstanceEventSubscription.new(@resource)
       event_subscription.name = 'DatabasesCountExceedsRecommended'
-      event_subscription.rds_event_category = 'notification'
-      event_subscription.message = 'The number of databases you have for your DB instance exceeds the recommended best practices for Amazon RDS.'
+      event_subscription.event_id = 'RDS-EVENT-0056'
       @event_subscriptions.push(event_subscription)
 
       event_subscription = CfnGuardian::Models::RDSInstanceEventSubscription.new(@resource)
       event_subscription.name = 'ReplicationFailure'
       event_subscription.enabled = false
-      event_subscription.rds_event_category = 'read replica'
-      event_subscription.message = 'An error has occurred in the read replication process.'
+      event_subscription.event_id = 'RDS-EVENT-0045'
       @event_subscriptions.push(event_subscription)
 
       event_subscription = CfnGuardian::Models::RDSInstanceEventSubscription.new(@resource)
       event_subscription.name = 'ReplicationTerminated'
       event_subscription.enabled = false
-      event_subscription.rds_event_category = 'read replica'
-      event_subscription.message = 'Replication on the read replica was terminated.'
+      event_subscription.event_id = 'RDS-EVENT-0057'
       @event_subscriptions.push(event_subscription)
 
       event_subscription = CfnGuardian::Models::RDSInstanceEventSubscription.new(@resource)
       event_subscription.name = 'ReplicationStopped'
       event_subscription.enabled = false
-      event_subscription.rds_event_category = 'read replica'
-      event_subscription.message = 'Replication on the read replica was manually stopped.'
+      event_subscription.event_id = 'RDS-EVENT-0062'
       @event_subscriptions.push(event_subscription)
     end
 

--- a/lib/cfnguardian/resources/rds_instance.rb
+++ b/lib/cfnguardian/resources/rds_instance.rb
@@ -107,12 +107,12 @@ module CfnGuardian::Resource
 
       event_subscription = CfnGuardian::Models::RDSInstanceEventSubscription.new(@resource)
       event_subscription.name = 'MultiAZFailoverStarted'
-      event_subscription.event_id = 'RDS-EVENT-0049'
+      event_subscription.event_id = 'RDS-EVENT-0050'
       @event_subscriptions.push(event_subscription)
 
       event_subscription = CfnGuardian::Models::RDSInstanceEventSubscription.new(@resource)
       event_subscription.name = 'MultiAZFailoverCompleted'
-      event_subscription.event_id = 'RDS-EVENT-0050'
+      event_subscription.event_id = 'RDS-EVENT-0049'
       @event_subscriptions.push(event_subscription)
 
       event_subscription = CfnGuardian::Models::RDSInstanceEventSubscription.new(@resource)

--- a/lib/cfnguardian/stacks/resources.rb
+++ b/lib/cfnguardian/stacks/resources.rb
@@ -112,7 +112,7 @@ module CfnGuardian
 
       def add_event_subscription(subscription)
         event_pattern = {}
-        event_pattern['detail-type'] = [subscription.detail_type]
+        event_pattern['detail-type'] = [subscription.detail_type] unless subscription.detail_type.empty?
         event_pattern['source'] = [subscription.source]
         event_pattern['resources'] = [subscription.resource_arn] unless subscription.resource_arn.empty?
         event_pattern['detail'] = subscription.detail unless subscription.detail.empty?


### PR DESCRIPTION
##Changes 

1. capturing the events via the event id rather than the message

  ```
  "EventID": "RDS-EVENT-0049"
  ```
  
  example events https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.overview.html#rds-cloudwatch-events.db-instances
  
  Event IDs https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.Messages.html#USER_Events.Messages.instance
  
2. Resource id matching for RDS events moved from detail to the resources key for a more reliable matching pattern

3. Fix tagging bug
The previous release introduced the ability to validate if a resource exists, this feature was missed on the tag-alarms command causing the command to fail. 