### PR TITLE
Add support for lambda aliases

### DIFF
--- a/lib/cfnguardian/models/alarm.rb
+++ b/lib/cfnguardian/models/alarm.rb
@@ -390,7 +390,12 @@ module CfnGuardian
         super(resource)
         @group = 'Lambda'
         @namespace = 'AWS/Lambda'
-        @dimensions = { FunctionName: resource['Id'] }
+        if resource['Id'].include?(':')
+          lambda_name, lambda_alias = resource['Id'].split(':', 2)
+          @dimensions = { FunctionName: lambda_name, Resource: resource['Id'] }
+        else
+          @dimensions = { FunctionName: resource['Id'] }
+        end     
         @statistic = 'Average'
         @evaluation_periods = 5
         @treat_missing_data = 'notBreaching'

--- a/lib/cfnguardian/version.rb
+++ b/lib/cfnguardian/version.rb
@@ -1,4 +1,4 @@
 module CfnGuardian
-  VERSION = "0.11.3"
+  VERSION = "0.11.4"
   CHANGE_SET_VERSION = VERSION.gsub('.', '-').freeze
 end


### PR DESCRIPTION
Added support for lambda aliases which are designated in the format of `LambdaName:Alias`, if a `:` is detected in the resource Id for a lambda resource the alarm will be created targeting the suffix alias, if no `:` is detected the logic remains the same as a normal lambda function alarm. 

## Example 
1. We start with 2 lambda functions, `NormalFunction` and `FunctionWithAlias` which has two alias `Dev` and `Prod`.
2. We deploy guardian with the following alarms.yaml template:
```yaml
Resources:
  Lambda:
  - Id: NormalFunction
  - Id: FunctionWithAlias:Dev
```

Observe that the resource id for `FunctionWithAlias` targets only the `Dev` alias whilst `NormalFunction` has no alias target as such remains the same as before.

3. Observe the created LambdaErrors alarms in Cloudwatch. Observe that the `Dev` alias is targeted in the `FunctionWithAlias` alarm.
   <img width="283" alt="Screen Shot 2023-07-28 at 11 20 42 am" src="https://github.com/base2Services/cfn-guardian/assets/64295670/783ec934-94ab-4633-92fd-ba752a61995c">
4. We then trigger a Lambda error in the `NormalFunction` and `FunctionWithAlias` **Prod** alias which we are **not** monitoring.

Normal Function           |  FunctionWithAlias (Prod Alias)
:-------------------------:|:-------------------------:
  <img width="508" alt="Screen Shot 2023-07-28 at 11 24 26 am" src="https://github.com/base2Services/cfn-guardian/assets/64295670/aa0ceb70-ef7d-409d-b595-f2a8c9e196bc">  | <img width="492" alt="Screen Shot 2023-07-28 at 11 24 09 am" src="https://github.com/base2Services/cfn-guardian/assets/64295670/42312707-3767-4c0f-bbef-eee3f711269f">  

5. Observe that the LambdaErrors alarm has triggered for `NormalFunction` as expected. Also observe it did not trigger of `FunctionWithAlias` as expected as the error occurred in the `Prod` alias but we are monitoring the `Dev` alias.
   
   <img width="279" alt="Screen Shot 2023-07-28 at 11 25 53 am" src="https://github.com/base2Services/cfn-guardian/assets/64295670/e19acf6a-db85-4e58-b620-9259cb335a98">

6. Now we trigger a lambda error in the `FunctionWithAlias` lambda on the `Dev` alias.
   <img width="523" alt="Screen Shot 2023-07-28 at 11 28 32 am" src="https://github.com/base2Services/cfn-guardian/assets/64295670/7e297df8-b136-46f1-a6a4-a2806f6cb4f5">

7. Observe the alarm for the `FunctionWithAlias` has triggered for the error induced on the `Dev` alias as expected.
   <img width="282" alt="Screen Shot 2023-07-28 at 11 29 19 am" src="https://github.com/base2Services/cfn-guardian/assets/64295670/6a156150-a822-4c01-b53f-d9fd29aca74d">
