### PR TITLE
Fix tagging for multiple alarm actions

### DIFF
--- a/lib/cfnguardian/tagger.rb
+++ b/lib/cfnguardian/tagger.rb
@@ -29,7 +29,11 @@ module CfnGuardian
         logger.debug "Updating tags on alarm #{alarm_arn}"
         new_tags.delete_if {|key, value| value.include?('?')}
         begin
-          @client.tag_resource({
+          alarm_severity = new_tags["guardian:alarm:severity"]
+          if alarm_severity.is_a?(Array)
+            new_tags["guardian:alarm:severity"] = new_tags["guardian:alarm:severity"].join("/")
+          end
+            @client.tag_resource({
             resource_arn: alarm_arn,
             tags: new_tags.map {|key,value| {key: key, value: value}}
           })

--- a/lib/cfnguardian/version.rb
+++ b/lib/cfnguardian/version.rb
@@ -1,4 +1,4 @@
 module CfnGuardian
-  VERSION = "0.11.4"
+  VERSION = "0.11.5"
   CHANGE_SET_VERSION = VERSION.gsub('.', '-').freeze
 end


### PR DESCRIPTION
Added fix for when there are multiple alarm actions associated with a single alarm causing tagging to fail. Tagging now checks if there are multiple severities and if so concatenates into single string joined with '/'.

### Issue
```
/usr/local/bundle/gems/aws-sdk-core-3.147.0/lib/aws-sdk-core/param_validator.rb:35:in `validate!': expected params[:tags][9][:value] to be a String, got value ["Critical", "EcsCycle"] (class: Array) instead. (ArgumentError)
```

### Solution Example 
1. Deploy alarm with multiple actions
   <img width="823" alt="Screen Shot 2023-08-17 at 11 56 31 am" src="https://github.com/base2Services/cfn-guardian/assets/64295670/c3fa2162-cd68-4aea-8fcb-23b264943a70">
2. Tag alarms via CLI
3. Observe the tags on the alarm now create successfully.
   <img width="611" alt="Screen Shot 2023-08-17 at 11 57 12 am" src="https://github.com/base2Services/cfn-guardian/assets/64295670/de91c2ff-20f1-4cf8-ae5e-74b2e7d38c0a">


### Single Action Alarms still work as expected.
   <img width="798" alt="Screen Shot 2023-08-17 at 11 51 10 am" src="https://github.com/base2Services/cfn-guardian/assets/64295670/acb24d5c-c918-4d4d-8625-463691dc00b6">
   <img width="335" alt="Screen Shot 2023-08-17 at 11 51 31 am" src="https://github.com/base2Services/cfn-guardian/assets/64295670/3d4f304e-33ba-4853-8652-351c22af1938">
