### PR TITLE
Nrpe inherit fix

### DIFF
--- a/lib/cfnguardian/resources/nrpe.rb
+++ b/lib/cfnguardian/resources/nrpe.rb
@@ -4,7 +4,7 @@ require 'cfnguardian/string'
 module CfnGuardian::Resource
   class Nrpe < Base
     
-    def initialize(resource)
+    def initialize(resource, override_group = nil)
       super(resource)
       @resource_list = resource['Hosts']
       @environment = resource['Environment']


### PR DESCRIPTION
Fixed issue where trying to compile when inheriting the Nrpe resource would cause a compilation error. 

Issue was there was no override group in the constructor for Nrpe causing it fail due to too many args in the constructor when inheriting.

### Before
```yaml
cfn-guardian-0.11.7/lib/cfnguardian/resources/nrpe.rb:7:in `initialize': wrong number of arguments (given 2, expected 1) (ArgumentError)
```

### After
```yaml
 cfn-guardian compile --config=config.yaml --region ap-southeast-2 --debug
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
DEBUG: Inherited resource group Nrpe for group NrpeNew
DEBUG: overriding CheckDiskCritical alarm properties for resource 1.234.56.7 in resource group NrpeNew via alarm overrides
DEBUG: overriding Alarm property 'AlarmAction' with value ["Critical", "Custom"] for resource id: 1.234.56.7
DEBUG: overriding CheckDiskCritical alarm properties for resource 9.876.54.3 in resource group NrpeNew via alarm overrides
DEBUG: overriding Alarm property 'AlarmAction' with value ["Critical", "Custom"] for resource id: 9.876.54.3
INFO: Cloudformation templates compiled successfully in out/ directory
INFO: Found bucket 123456789123.ap-southeast-2.guardian.templates
INFO: Validating template out/guardian.compiled.yaml locally
```