### PR TITLE
Add the option to disable the OK action

### DIFF
--- a/docs/alarm_templates.md
+++ b/docs/alarm_templates.md
@@ -29,6 +29,7 @@ cfn-guardian show-alarms --defaults --group ApplicationTargetGroup --alarm Targe
 | ActionsEnabled          | true                             |
 | AlarmAction             | Critical                         |
 | TreatMissingData        | notBreaching                     |
+| OkActionDisabled        | false                            |
 +-------------------------+----------------------------------+
 ```
 
@@ -111,6 +112,19 @@ Templates:
   Ec2Instance:
     # define the Alarm and set the value to false
     CPUUtilizationHigh: false
+```
+
+## Disabling The OK Action On An Alarm
+
+You can disable the OK action on an alarm by setting the OkActionDisabled flag to `true`. You might want to do this if you just want to receive alarm notifications rather than treat it as stateful.
+
+```yaml
+Templates:
+  # define the resource group
+  Ec2Instance:
+    # define the Alarm and set the OkActionDisabled value to true
+    CPUUtilizationHigh:
+    OkActionDisabled: true
 ```
 
 ## M Out Of N Metric Data Points

--- a/lib/cfnguardian/display_formatter.rb
+++ b/lib/cfnguardian/display_formatter.rb
@@ -32,6 +32,7 @@ module CfnGuardian
           ['EvaluateLowSampleCountPercentile', alarm.evaluate_low_sample_count_percentile],
           ['Unit', alarm.unit],
           ['AlarmAction', alarm.alarm_action],
+          ['OkActionDisabled', alarm.ok_action_disabled],
           ['TreatMissingData', alarm.treat_missing_data]
         ]
         
@@ -72,7 +73,8 @@ module CfnGuardian
           ['EvaluateLowSampleCountPercentile', alarm.evaluate_low_sample_count_percentile, metric_alarm.evaluate_low_sample_count_percentile],
           ['Unit', alarm.unit, metric_alarm.unit],
           ['TreatMissingData', alarm.treat_missing_data, metric_alarm.treat_missing_data],
-          ['AlarmAction', alarm.alarm_action, alarm.alarm_action]
+          ['AlarmAction', alarm.alarm_action, alarm.alarm_action],
+          ['OkActionDisabled', alarm.ok_action_disabled]
         ]
         
         rows.select! {|row| !row[1].nil?}.each {|row| colour_compare_row(row)}

--- a/lib/cfnguardian/models/alarm.rb
+++ b/lib/cfnguardian/models/alarm.rb
@@ -19,6 +19,7 @@ module CfnGuardian
         :comparison_operator,
         :statistic,
         :actions_enabled,
+        :ok_action_disabled,
         :enabled,
         :resource_id,
         :resource_name,
@@ -45,6 +46,7 @@ module CfnGuardian
         @comparison_operator = 'GreaterThanThreshold'
         @statistic = 'Maximum'
         @actions_enabled = true
+        @ok_action_disabled = false
         @datapoints_to_alarm = nil
         @extended_statistic = nil
         @evaluate_low_sample_count_percentile = nil

--- a/lib/cfnguardian/stacks/resources.rb
+++ b/lib/cfnguardian/stacks/resources.rb
@@ -48,7 +48,7 @@ module CfnGuardian
             MetricName alarm.metric_name
             Namespace alarm.namespace
             AlarmActions actions
-            OKActions actions
+            OKActions actions unless alarm.ok_action_disabled
             TreatMissingData alarm.treat_missing_data unless alarm.treat_missing_data.nil?
             DatapointsToAlarm alarm.datapoints_to_alarm unless alarm.datapoints_to_alarm.nil?
             ExtendedStatistic alarm.extended_statistic unless alarm.extended_statistic.nil?

--- a/lib/cfnguardian/version.rb
+++ b/lib/cfnguardian/version.rb
@@ -1,4 +1,4 @@
 module CfnGuardian
-  VERSION = "0.11.11"
+  VERSION = "0.11.12"
   CHANGE_SET_VERSION = VERSION.gsub('.', '-').freeze
 end


### PR DESCRIPTION
It was requested to remove the OK action to reduce noise, so this allows it to be configurable but enabled by default.